### PR TITLE
feat: make links clickable in preview panel

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -5,6 +5,8 @@ const VIEW_TYPE_NOTE_PREVIEW = "canvas-note-preview";
 // Canvas 相關的介面定義
 interface CanvasNode {
 	file?: TFile;
+	text?: string;
+	label?: string;
 	type?: string;
 }
 
@@ -373,6 +375,40 @@ class NotePreviewView extends ItemView {
 		});
 	}
 
+	async setTextContent(text: string, label: string) {
+		this.currentFile = null;
+		const container = this.containerEl.children[1];
+
+		if (!container) return;
+
+		container.empty();
+
+		const header = container.createDiv({ cls: 'canvas-note-preview-header' });
+		const titleRow = header.createDiv({ cls: 'canvas-note-preview-title-row' });
+
+		this.backBtn = titleRow.createEl('button', { text: '\u2190' });
+		this.backBtn.addClass('canvas-note-preview-back-btn');
+		this.backBtn.title = 'Back';
+		if (this.history.length === 0) {
+			this.backBtn.addClass('is-disabled');
+			this.backBtn.disabled = true;
+		}
+		this.backBtn.onclick = () => {
+			void this.goBack();
+		};
+
+		titleRow.createEl('h3', { text: label });
+
+		this.previewContainer = container.createDiv({ cls: 'canvas-note-preview-content' });
+
+		try {
+			await MarkdownRenderer.render(this.app, text, this.previewContainer, '', this);
+			this.attachLinkHandler(this.previewContainer);
+		} catch {
+			this.previewContainer.setText('Failed to render text content');
+		}
+	}
+
 	private async goBack() {
 		if (this.history.length === 0) return;
 		const prevFile = this.history.pop();
@@ -481,6 +517,8 @@ export default class CanvasNotePreviewPlugin extends Plugin {
 					// 檢查是否為檔案節點
 					if (node && node.file && node.file instanceof TFile) {
 						void this.showNoteInPreview(node.file);
+					} else if (node && node.text != null && !node.file) {
+						void this.showTextInPreview(node.text, node.label || 'Text node');
 					}
 				}
 			}, 50);
@@ -495,15 +533,24 @@ export default class CanvasNotePreviewPlugin extends Plugin {
 	}
 
 	async showNoteInPreview(file: TFile) {
-		// 如果預覽面板還沒打開，先打開它
 		if (!this.previewLeaf) {
 			await this.activateView();
 		}
 
-		// 更新預覽內容
 		const view = this.previewLeaf?.view;
 		if (view && view instanceof NotePreviewView) {
 			await view.setFile(file);
+		}
+	}
+
+	async showTextInPreview(text: string, label: string) {
+		if (!this.previewLeaf) {
+			await this.activateView();
+		}
+
+		const view = this.previewLeaf?.view;
+		if (view && view instanceof NotePreviewView) {
+			await view.setTextContent(text, label);
 		}
 	}
 }

--- a/main.ts
+++ b/main.ts
@@ -144,13 +144,17 @@ class NotePreviewView extends ItemView {
 			this.editor.value = fileContent;
 
 			// 渲染預覽
-			await MarkdownRenderer.render(
-				this.app,
-				fileContent,
-				this.previewContainer,
-				file.path,
-				this
-			);
+			if (file.extension === 'canvas') {
+				this.renderCanvasPreview(fileContent, this.previewContainer);
+			} else {
+				await MarkdownRenderer.render(
+					this.app,
+					fileContent,
+					this.previewContainer,
+					file.path,
+					this
+				);
+			}
 			this.attachLinkHandler(this.previewContainer);
 
 			// 預設顯示預覽模式
@@ -283,6 +287,49 @@ class NotePreviewView extends ItemView {
 	 * Handles both external file:/// links (opens in system file explorer)
 	 * and internal vault links (navigates within the preview panel).
 	 */
+	private renderCanvasPreview(jsonContent: string, container: HTMLElement) {
+		try {
+			const data = JSON.parse(jsonContent);
+			const nodes: Array<{type?: string; label?: string; file?: string; text?: string}> = data.nodes || [];
+			const groups = nodes.filter(n => n.type === 'group');
+			const fileNodes = nodes.filter(n => n.type === 'file');
+			const textNodes = nodes.filter(n => n.type === 'text');
+			const edges: unknown[] = data.edges || [];
+
+			let md = '**Double click the card to open this canvas**\n\n';
+			md += `${nodes.length} nodes \u00B7 ${edges.length} edges\n\n`;
+
+			if (groups.length > 0) {
+				md += '### Groups\n';
+				groups.forEach(g => {
+					md += `- ${g.label || 'Untitled group'}\n`;
+				});
+				md += '\n';
+			}
+
+			if (fileNodes.length > 0) {
+				md += '### Files\n';
+				fileNodes.forEach(f => {
+					const name = f.file ? f.file.split('/').pop() : 'Unknown';
+					md += `- [[${f.file || ''}|${name}]]\n`;
+				});
+				md += '\n';
+			}
+
+			if (textNodes.length > 0) {
+				md += '### Notes\n';
+				textNodes.forEach(t => {
+					const preview = (t.text || '').split('\n')[0].replace(/^#+\s*/, '').substring(0, 60);
+					md += `- ${preview}\n`;
+				});
+			}
+
+			MarkdownRenderer.render(this.app, md, container, '', this);
+		} catch {
+			container.setText('Could not parse canvas file');
+		}
+	}
+
 	private attachLinkHandler(container: HTMLElement) {
 		container.addEventListener('click', (e: MouseEvent) => {
 			const link = (e.target as HTMLElement).closest('a');

--- a/main.ts
+++ b/main.ts
@@ -135,6 +135,7 @@ class NotePreviewView extends ItemView {
 				file.path,
 				this
 			);
+			this.attachLinkHandler(this.previewContainer);
 
 			// 預設顯示預覽模式
 			this.showPreview();
@@ -227,6 +228,7 @@ class NotePreviewView extends ItemView {
 				this.currentFile.path,
 				this
 			);
+			this.attachLinkHandler(this.previewContainer);
 		} catch (error) {
 			console.error('Error rendering preview:', error);
 			this.previewContainer.setText('Failed to render preview');
@@ -258,6 +260,51 @@ class NotePreviewView extends ItemView {
 				this.saveStatusEl.addClass('save-status-error');
 				break;
 		}
+	}
+
+	/**
+	 * Attach click handlers to make links interactive in the preview panel.
+	 * Handles both external file:/// links (opens in system file explorer)
+	 * and internal vault links (navigates within the preview panel).
+	 */
+	private attachLinkHandler(container: HTMLElement) {
+		container.addEventListener('click', (e: MouseEvent) => {
+			const link = (e.target as HTMLElement).closest('a');
+			if (!link) return;
+
+			const href = link.getAttribute('href');
+
+			// Handle external file:/// links
+			if (href && href.startsWith('file:///')) {
+				e.preventDefault();
+				e.stopPropagation();
+				const decodedPath = decodeURIComponent(href.replace('file:///', '')).replace(/\//g, '\\');
+				try {
+					// eslint-disable-next-line @typescript-eslint/no-var-requires
+					const { exec } = require('child_process');
+					exec(`explorer.exe "${decodedPath}"`);
+				} catch (err) {
+					console.error('Failed to open external path:', err);
+				}
+				return;
+			}
+
+			// Handle internal vault links
+			if (link.classList.contains('internal-link')) {
+				e.preventDefault();
+				e.stopPropagation();
+				const dataHref = link.getAttribute('data-href') || href;
+				if (dataHref) {
+					const targetFile = this.app.metadataCache.getFirstLinkpathDest(
+						dataHref,
+						this.currentFile ? this.currentFile.path : ''
+					);
+					if (targetFile) {
+						void this.setFile(targetFile);
+					}
+				}
+			}
+		});
 	}
 
 	async onClose() {

--- a/main.ts
+++ b/main.ts
@@ -27,6 +27,8 @@ class NotePreviewView extends ItemView {
 	private saveTimeout: number | null = null;
 	private saveStatusEl: HTMLElement | null = null;
 	private toggleBtn: HTMLButtonElement | null = null;
+	private backBtn: HTMLButtonElement | null = null;
+	private history: TFile[] = [];
 
 	constructor(leaf: WorkspaceLeaf) {
 		super(leaf);
@@ -75,7 +77,21 @@ class NotePreviewView extends ItemView {
 
 		// 建立標題區
 		const header = container.createDiv({ cls: 'canvas-note-preview-header' });
-		header.createEl('h3', { text: file?.basename || 'Untitled' });
+		const titleRow = header.createDiv({ cls: 'canvas-note-preview-title-row' });
+
+		// 建立返回按鈕
+		this.backBtn = titleRow.createEl('button', { text: '\u2190' });
+		this.backBtn.addClass('canvas-note-preview-back-btn');
+		this.backBtn.title = 'Back';
+		if (this.history.length === 0) {
+			this.backBtn.addClass('is-disabled');
+			this.backBtn.disabled = true;
+		}
+		this.backBtn.onclick = () => {
+			void this.goBack();
+		};
+
+		titleRow.createEl('h3', { text: file?.basename || 'Untitled' });
 
 		// 建立按鈕容器
 		const buttonContainer = header.createDiv({ cls: 'canvas-note-preview-buttons' });
@@ -300,11 +316,22 @@ class NotePreviewView extends ItemView {
 						this.currentFile ? this.currentFile.path : ''
 					);
 					if (targetFile) {
+						if (this.currentFile) {
+							this.history.push(this.currentFile);
+						}
 						void this.setFile(targetFile);
 					}
 				}
 			}
 		});
+	}
+
+	private async goBack() {
+		if (this.history.length === 0) return;
+		const prevFile = this.history.pop();
+		if (prevFile) {
+			await this.setFile(prevFile);
+		}
 	}
 
 	async onClose() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "canvas-note-preview",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "canvas-note-preview",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^16.11.6",

--- a/styles.css
+++ b/styles.css
@@ -24,6 +24,46 @@
 	gap: 10px;
 }
 
+.canvas-note-preview-title-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex: 1;
+	min-width: 150px;
+}
+
+.canvas-note-preview-title-row h3 {
+	margin: 0;
+	font-size: 18px;
+}
+
+.canvas-note-preview-back-btn {
+	padding: 2px 8px;
+	font-size: 14px;
+	background: var(--background-modifier-border);
+	color: var(--text-normal);
+	border: none;
+	border-radius: 4px;
+	cursor: pointer;
+	transition: background 0.2s;
+	flex-shrink: 0;
+}
+
+.canvas-note-preview-back-btn:hover {
+	background: var(--interactive-accent);
+	color: var(--text-on-accent);
+}
+
+.canvas-note-preview-back-btn.is-disabled {
+	opacity: 0.3;
+	cursor: default;
+}
+
+.canvas-note-preview-back-btn.is-disabled:hover {
+	background: var(--background-modifier-border);
+	color: var(--text-normal);
+}
+
 .canvas-note-preview-header h3 {
 	margin: 0;
 	font-size: 18px;


### PR DESCRIPTION
Add click handler for rendered markdown in the preview panel:
- External file:/// links open in system file explorer
- Internal vault links navigate within the preview panel

Previously, links rendered by MarkdownRenderer were not interactive in the preview panel. This adds an event listener after each render that intercepts clicks on anchor elements and handles them appropriately based on link type.